### PR TITLE
Update to ElasticSearch 2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ repositories {
 dependencies {
     provided "org.apache.flume:flume-ng-core:1.6.0"
     provided 'org.apache.flume.flume-ng-sinks:flume-ng-elasticsearch-sink:1.6.0'
-    compile 'org.elasticsearch:elasticsearch:2.1.0'
+    compile 'org.elasticsearch:elasticsearch:2.2.0'
     testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ repositories {
 dependencies {
     provided "org.apache.flume:flume-ng-core:1.6.0"
     provided 'org.apache.flume.flume-ng-sinks:flume-ng-elasticsearch-sink:1.6.0'
-    compile 'org.elasticsearch:elasticsearch:2.0.0'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
+    compile 'org.elasticsearch:elasticsearch:2.1.0'
+    testCompile group: 'junit', name: 'junit', version: '4.12'
 }
 
 task assembly(type: Jar) {


### PR DESCRIPTION
Update version of elasticsearch to avoid java.lang.NoSuchFieldError: LUCENE_5_3_1 when using elasticsearch 2.1.0.
