### PR TITLE
Multiple code improvements - squid:S1118, squid:S1854, squid:S1213

### DIFF
--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchSinkConstants.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchSinkConstants.java
@@ -106,4 +106,6 @@ public class ElasticSearchSinkConstants {
   public static final String TTL_REGEX = "^(\\d+)(\\D*)";
   public static final String DEFAULT_SERIALIZER_CLASS = "com.frontier45.flume.sink.elasticsearch2.ElasticSearchLogStashEventSerializer";
   public static final String DEFAULT_INDEX_NAME_BUILDER_CLASS = "com.frontier45.flume.sink.elasticsearch2.TimeBasedIndexNameBuilder";
+
+  private ElasticSearchSinkConstants() {}
 }

--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/client/ElasticSearchTransportClient.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/client/ElasticSearchTransportClient.java
@@ -54,16 +54,6 @@ public class ElasticSearchTransportClient implements ElasticSearchClient {
 
     private Client client;
 
-    @VisibleForTesting
-    InetSocketTransportAddress[] getServerAddresses() {
-        return serverAddresses;
-    }
-
-    @VisibleForTesting
-    void setBulkRequestBuilder(BulkRequestBuilder bulkRequestBuilder) {
-        this.bulkRequestBuilder = bulkRequestBuilder;
-    }
-
     /**
      * Transport client for external cluster
      *
@@ -129,6 +119,16 @@ public class ElasticSearchTransportClient implements ElasticSearchClient {
         requestBuilderFactory.createIndexRequest(client, null, null, null);
     }
 
+    @VisibleForTesting
+    InetSocketTransportAddress[] getServerAddresses() {
+        return serverAddresses;
+    }
+
+    @VisibleForTesting
+    void setBulkRequestBuilder(BulkRequestBuilder bulkRequestBuilder) {
+        this.bulkRequestBuilder = bulkRequestBuilder;
+    }
+
     private void configureHostnames(String[] hostNames) {
         logger.warn(Arrays.toString(hostNames));
         serverAddresses = new InetSocketTransportAddress[hostNames.length];
@@ -156,7 +156,7 @@ public class ElasticSearchTransportClient implements ElasticSearchClient {
             bulkRequestBuilder = client.prepareBulk();
         }
 
-        IndexRequestBuilder indexRequestBuilder = null;
+        IndexRequestBuilder indexRequestBuilder;
         if (indexRequestBuilderFactory == null) {
             indexRequestBuilder = client
                     .prepareIndex(indexNameBuilder.getIndexName(event), indexType)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1854 - Dead stores should be removed.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
This pull request removes 75 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava
