### PR TITLE
Multiple code improvements - squid:S1192, squid:S2259, squid:S2864, squid:RedundantThrowsDeclarationCheck, squid:S2184

### DIFF
--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchDynamicSerializer.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchDynamicSerializer.java
@@ -22,6 +22,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.flume.Context;
 import org.apache.flume.Event;
@@ -64,9 +65,9 @@ public class ElasticSearchDynamicSerializer implements
   private void appendHeaders(XContentBuilder builder, Event event)
       throws IOException {
     Map<String, String> headers = event.getHeaders();
-    for (String key : headers.keySet()) {
-      ContentBuilderUtil.appendField(builder, key,
-              headers.get(key).getBytes(charset));
+    for (Map.Entry<String, String> entry : headers.entrySet()) {
+      ContentBuilderUtil.appendField(builder, entry.getKey(),
+              entry.getValue().getBytes(charset));
     }
   }
 

--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchLogStashEventSerializer.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchLogStashEventSerializer.java
@@ -83,7 +83,7 @@ public class ElasticSearchLogStashEventSerializer implements
     }
 
     private void appendBody(XContentBuilder builder, Event event)
-            throws IOException, UnsupportedEncodingException {
+            throws IOException {
         byte[] body = event.getBody();
         ContentBuilderUtil.appendField(builder, "@message", body);
     }
@@ -127,9 +127,9 @@ public class ElasticSearchLogStashEventSerializer implements
         }
 
         builder.startObject("@fields");
-        for (String key : headers.keySet()) {
-            byte[] val = headers.get(key).getBytes(charset);
-            ContentBuilderUtil.appendField(builder, key, val);
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            byte[] val = entry.getValue().getBytes(charset);
+            ContentBuilderUtil.appendField(builder, entry.getKey(), val);
         }
         builder.endObject();
     }

--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchSink.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/ElasticSearchSink.java
@@ -66,6 +66,8 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
 
   private static final Logger logger = LoggerFactory
       .getLogger(ElasticSearchSink.class);
+  public static final String FAILED_TO_COMMIT_TRANSACTION_TRANSACTION_ROLLED_BACK = "Failed to commit transaction. Transaction rolled back.";
+  public static final String MISSING_PARAM = "Missing Param:";
 
   // Used for testing
   private boolean isLocal = false;
@@ -198,14 +200,14 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
       }
 
       if (ex instanceof Error || ex instanceof RuntimeException) {
-        logger.error("Failed to commit transaction. Transaction rolled back.",
+        logger.error(FAILED_TO_COMMIT_TRANSACTION_TRANSACTION_ROLLED_BACK,
             ex);
         Throwables.propagate(ex);
       } else {
-        logger.error("Failed to commit transaction. Transaction rolled back.",
+        logger.error(FAILED_TO_COMMIT_TRANSACTION_TRANSACTION_ROLLED_BACK,
             ex);
         throw new EventDeliveryException(
-            "Failed to commit transaction. Transaction rolled back.", ex);
+                FAILED_TO_COMMIT_TRANSACTION_TRANSACTION_ROLLED_BACK, ex);
       }
     } finally {
       txn.close();
@@ -221,7 +223,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
             context.getString(ElasticSearchSinkConstants.HOSTNAMES)).split(",");
       }
       Preconditions.checkState(serverAddresses != null
-          && serverAddresses.length > 0, "Missing Param:" + ElasticSearchSinkConstants.HOSTNAMES);
+          && serverAddresses.length > 0, MISSING_PARAM + ElasticSearchSinkConstants.HOSTNAMES);
     }
 
     if (StringUtils.isNotBlank(context.getString(ElasticSearchSinkConstants.INDEX_NAME))) {
@@ -314,11 +316,11 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
     }
 
     Preconditions.checkState(StringUtils.isNotBlank(indexName),
-        "Missing Param:" + ElasticSearchSinkConstants.INDEX_NAME);
+        MISSING_PARAM + ElasticSearchSinkConstants.INDEX_NAME);
     Preconditions.checkState(StringUtils.isNotBlank(indexType),
-        "Missing Param:" + ElasticSearchSinkConstants.INDEX_TYPE);
+        MISSING_PARAM + ElasticSearchSinkConstants.INDEX_TYPE);
     Preconditions.checkState(StringUtils.isNotBlank(clusterName),
-        "Missing Param:" + ElasticSearchSinkConstants.CLUSTER_NAME);
+        MISSING_PARAM + ElasticSearchSinkConstants.CLUSTER_NAME);
     Preconditions.checkState(batchSize >= 1, ElasticSearchSinkConstants.BATCH_SIZE
         + " must be greater than 0");
   }
@@ -392,7 +394,7 @@ public class ElasticSearchSink extends AbstractSink implements Configurable {
       } else if (matcher.group(2).equals("d")) {
         return TimeUnit.DAYS.toMillis(Integer.parseInt(matcher.group(1)));
       } else if (matcher.group(2).equals("w")) {
-        return TimeUnit.DAYS.toMillis(7 * Integer.parseInt(matcher.group(1)));
+        return TimeUnit.DAYS.toMillis(7L * Integer.parseInt(matcher.group(1)));
       } else if (matcher.group(2).equals("")) {
         logger.info("TTL qualifier is empty. Defaulting to day qualifier.");
         return TimeUnit.DAYS.toMillis(Integer.parseInt(matcher.group(1)));

--- a/src/main/java/com/frontier45/flume/sink/elasticsearch2/client/ElasticSearchRestClient.java
+++ b/src/main/java/com/frontier45/flume/sink/elasticsearch2/client/ElasticSearchRestClient.java
@@ -136,7 +136,7 @@ public class ElasticSearchRestClient implements ElasticSearchClient {
         }
 
         if (statusCode != HttpStatus.SC_OK) {
-            if (response.getEntity() != null) {
+            if (response != null && response.getEntity() != null) {
                 throw new EventDeliveryException(EntityUtils.toString(response.getEntity(), "UTF-8"));
             } else {
                 throw new EventDeliveryException("Elasticsearch status code was: " + statusCode);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:S2259 - Null pointers should not be dereferenced.
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S2184 - Math operands should be cast before assignment.
This pull request removes 48 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S2259
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2184
Please let me know if you have any questions.
George Kankava
